### PR TITLE
[0.2.0] - Migrate RoxyMenu to New Input Stack API

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,42 @@
+# Breaking Changes
+
+This document catalogs all **breaking changes** introduced across the Roxy Menu’s releases. Each section below corresponds to a specific version that included incompatible updates requiring developers to adjust their code. For migration details on each change, see the corresponding **code references** and recommended actions.
+
+---
+
+## [0.2.0] - 2025-06-11
+
+### Input Handler System Overhauled
+
+**What Changed:**
+- Replaced deprecated input methods `roxy.Input.saveAndSetHandler()` and `roxy.Input.restoreHandler()` with the new `roxy.Input.addHandler()` and `roxy.Input.removeHandler()`.
+- Added support for `roxy.Input.makeModalHandler()` to explicitly block input from lower-priority handlers.
+
+**Required Updates:**
+- If you override or extend `RoxyMenu:activate()` or `:deactivate()`, update all input logic:
+
+  - **Before:**
+    ```lua
+    roxy.Input.saveAndSetHandler(handler, true)
+    roxy.Input.restoreHandler()
+    ```
+
+  - **After:**
+    ```lua
+    handler = roxy.Input.makeModalHandler(handler) -- Optional for modal
+    roxy.Input.addHandler(self, handler, 100)
+    roxy.Input.removeHandler(self)
+    ```
+
+- Ensure you remove all usage of `saveAndSetHandler`, `restoreHandler`, and any fallback stack-based handler logic.
+- Assign an appropriate priority (e.g., 100+) for modal menus to override gameplay or scene input handlers.
+
+**Reason:**
+This change was necessary to align `RoxyMenu` with `roxy-engine`’s new input architecture, which uses an explicit, priority-based stack. It improves input predictability, supports simultaneous contexts, and integrates more cleanly with scenes and transitions.
+
+---
+
+## **Additional Notes**
+
+- If you’re **upgrading multiple versions**, review **each** relevant section above to ensure your project is updated correctly at every step.
+- For more details on specific changes (including the rationale or performance impact), see the [CHANGELOG.md](./CHANGELOG.md) file or individual commit messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [0.2.0] - 2025-06-11
+### Added ✨
+- Added support for new priority-based input system via `roxy.Input.addHandler()` and `removeHandler()`
+- Integrated `roxy.Input.makeModalHandler()` for modal input masking in `RoxyMenu`
+
+### Changed 🔧
+- Updated `RoxyMenu` to use explicit input ownership with `addHandler` and `removeHandler`
+- Replaced deprecated input stack calls with new API to align with `roxy-engine`'s input model
+
+### Removed ❌
+- Removed usage of legacy `saveAndSetHandler()` and `restoreHandler()` in input setup
+
+### Breaking Changes ⚠️
+- `RoxyMenu` now requires `roxy.Input.addHandler()` and `removeHandler()` for input management  
+- **Migration:**  
+  - Replace:
+    ```lua
+    roxy.Input.saveAndSetHandler(...)
+    roxy.Input.restoreHandler()
+    ```
+    with:
+    ```lua
+    roxy.Input.addHandler(self, handler, 100)
+    roxy.Input.removeHandler(self)
+    ```
+  - For modal menus, wrap handlers using `roxy.Input.makeModalHandler(handler)`
+  - See [BREAKING_CHANGES.md](./BREAKING_CHANGES.md) for full details
+
+---
+
 ## [0.1.0] - 2025-05-30
 
 ### Added ✨

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ menu:activate()
 
 ## Requirements
 
-This plugin is designed to be used **with the [Roxy Engine](https://github.com/invisiblesloth/roxy-engine)**.  
+This plugin is designed to be used **with the [Roxy Engine](https://github.com/invisiblesloth/roxy-engine)**.
 It relies on Roxy’s:
 
 - Sprite subclassing (`RoxySprite`)
@@ -75,11 +75,14 @@ RoxyMenu(menuItems, props)
 
 ### Activation and Deactivation
 
-- `menu:activate(pushHandler, handlerOverride, masksPreviousHandlers)`
-  - Activates the menu. Optional parameters control input handling.
+- `menu:activate(handlerOverride)`
+
+  - Activates the menu. Optionally override the default input handler.
+  - Uses `roxy.Input.addHandler()` internally.
 
 - `menu:deactivate()`
-  - Deactivates the menu and restores previous input handlers.
+
+  - Deactivates the menu and calls `roxy.Input.removeHandler()`.
 
 ### Menu Item Manipulation
 
@@ -118,7 +121,7 @@ local props = {
   crankThreshold = 20,
   holdDelay = 500,
   dismissible = true,
-  modal = false,
+  modal = false, -- If true, handler is wrapped in makeModalHandler()
   onDismiss = function() end
 }
 ```

--- a/core/RoxyMenu.lua
+++ b/core/RoxyMenu.lua
@@ -197,6 +197,7 @@ end
 -- ! Public Methods
 --
 
+-- ! Activate
 function RoxyMenu:activate(pushHandler, handlerOverride)
   if self.isActive then return self end
 

--- a/core/RoxyMenu.lua
+++ b/core/RoxyMenu.lua
@@ -42,8 +42,8 @@ local fillRoundRect     <const> = Graphics.fillRoundRect
 local getFontOffset     <const> = Text.getFontOffset
 
 -- Input
-local saveAndSetHandler <const> = roxy.Input.saveAndSetHandler
-local restoreHandler    <const> = roxy.Input.restoreHandler
+local addHandler    <const> = roxy.Input.addHandler
+local removeHandler <const> = roxy.Input.removeHandler
 
 -- Sounds
 local loadSound         <const> = Sounds.load
@@ -79,10 +79,10 @@ local CONTENT_INSET_VERTICAL_DEFAULT   <const> = 2   -- Inner top/bottom inset
 local CORNER_RADIUS_DEFAULT            <const> = 4   -- Menu corner radius
 local SELECTED_CORNER_RADIUS_DEFAULT   <const> = 4   -- Selection radius
 
-local setupDimensions   <const> = import "libraries/roxy-menu/core/RoxyMenuDimensions"
-local setupGridview     <const> = import "libraries/roxy-menu/core/RoxyMenuGridview"
-local setupSprite       <const> = import "libraries/roxy-menu/core/RoxyMenuSprite"
-local makeInputHandler  <const> = import "libraries/roxy-menu/core/RoxyMenuInput"
+local setupDimensions  <const> = import "libraries/roxy-menu/core/RoxyMenuDimensions"
+local setupGridview    <const> = import "libraries/roxy-menu/core/RoxyMenuGridview"
+local setupSprite      <const> = import "libraries/roxy-menu/core/RoxyMenuSprite"
+local makeInputHandler <const> = import "libraries/roxy-menu/core/RoxyMenuInput"
 
 class("RoxyMenu").extends(RoxySprite)
 
@@ -197,37 +197,42 @@ end
 -- ! Public Methods
 --
 
--- ! Activate
-function RoxyMenu:activate(pushHandler, handlerOverride, masksPreviousHandlers)
+function RoxyMenu:activate(pushHandler, handlerOverride)
   if self.isActive then return self end
 
   self.isActive = true
   self.listview:setSelectedRow(1)
   self:markDirty()
 
-  -- Push input handler unless explicitly disabled
   if pushHandler ~= false then
     local handlerSpec = handlerOverride or self._inputHandler
     local handler
 
     if handlerSpec then
-      if type_(handlerSpec) ~= "function" and type_(handlerSpec) ~= "table" then logWarn("RoxyMenu: Invalid inputHandler type (" .. type_(handlerSpec) .. "). Expected function or table.") end --#DEBUG
-
-      -- Convert function → table
-      handler = (type_(handlerSpec) == "function") and handlerSpec(self) or handlerSpec
+      --#DEBUG START
+      if type(handlerSpec) ~= "function" and type(handlerSpec) ~= "table" then
+        logWarn("RoxyMenu: Invalid inputHandler type (" .. type(handlerSpec) .. "). Expected function or table.")
+      end
+      --#DEBUG END
+      handler = (type(handlerSpec) == "function") and handlerSpec(self) or handlerSpec
       self._inputHandler = handlerSpec
-    else
-      handler = makeInputHandler(self)
+    end
+
+    -- Always try to get a handler, fallback to default if needed
+    if not handler then
+      handler = makeInputHandler and makeInputHandler(self) or {}
+    end
+
+    -- Fill all keys if modal, to fully mask input below
+    if self.modal and roxy.Input.makeModalHandler then
+      handler = roxy.Input.makeModalHandler(handler)
     end
 
     if handler then
-      saveAndSetHandler(
-        handler,
-        (masksPreviousHandlers ~= nil) and masksPreviousHandlers or self.modal
-      )
+      addHandler(self, handler, 100)
       self._inputHandlerPushed = true
-    else
-      logWarn("RoxyMenu: Failed to construct valid input handler. Skipping input push.") --#DEBUG
+    else --#DEBUG
+      logWarn("RoxyMenu: Failed to construct valid input handler. Skipping input registration.") --#DEBUG
     end
   end
 
@@ -237,10 +242,10 @@ end
 -- ! Deactivate
 function RoxyMenu:deactivate()
   if self._inputHandlerPushed then
-    restoreHandler()
+    removeHandler(self)
     self._inputHandlerPushed = false
-  else
-    logWarn("RoxyMenu: attempted to pop input handler, but it wasn't pushed.") --#DEBUG
+  else --#DEBUG
+    logWarn("RoxyMenu: attempted to remove input handler, but it wasn't registered.") --#DEBUG
   end
 
   self.isActive = false


### PR DESCRIPTION
### Overview
This release migrates the `RoxyMenu` plugin to the new priority-based input handler stack introduced in `roxy.Input`. It replaces legacy stack manipulation functions with explicit handler registration to improve compatibility and maintainability.

### Key Changes
- Replaced `saveAndSetHandler`/`restoreHandler` with `addHandler` and `removeHandler`
- Integrated `roxy.Input.makeModalHandler()` for proper modal masking
- Updated `RoxyMenu` activation/deactivation logic to align with new input model

### Challenges/Notes
- Migration introduces a breaking change; any plugin extending `RoxyMenu` must update input logic accordingly.